### PR TITLE
Add guest login with shared, reset-on-login account

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.4",
         "autoprefixer": "^10.4.21",
-        "babel-plugin-react-compiler": "^19.1.0-rc.3",
         "baseline-browser-mapping": "^2.9.14",
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -2104,16 +2103,6 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler": {
-      "version": "19.1.0-rc.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.1.0-rc.3.tgz",
-      "integrity": "sha512-mjRn69WuTz4adL0bXGx8Rsyk1086zFJeKmes6aK0xPuK3aaXmDJdLHqwKKMrpm6KAI1MCoUK72d2VeqQbu8YIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.4",
     "autoprefixer": "^10.4.21",
-    "babel-plugin-react-compiler": "^19.1.0-rc.3",
     "baseline-browser-mapping": "^2.9.14",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/components/Navbar/MobileMenu.tsx
+++ b/src/components/Navbar/MobileMenu.tsx
@@ -9,6 +9,7 @@ interface MobileMenuProps {
 	isAuthenticated: boolean;
 	user: { username: string; coins: number } | null;
 	onLogout: () => void;
+	onGuestLogin: () => void;
 }
 
 const navLinks = [
@@ -25,6 +26,7 @@ const MobileMenu = ({
 	isAuthenticated,
 	user,
 	onLogout,
+	onGuestLogin,
 }: MobileMenuProps) => {
 	const menuRef = useRef<HTMLDivElement>(null);
 
@@ -123,14 +125,25 @@ const MobileMenu = ({
 							Sign Out
 						</button>
 					) : (
-						<NavLink
-							to={ROUTES.LOGIN}
-							onClick={onClose}
-							className="block w-full px-4 py-3 rounded-lg text-white font-medium text-center hover:opacity-90 transition-opacity"
-							style={{ background: "#3434a5" }}
-						>
-							Sign In
-						</NavLink>
+						<div className="flex flex-col gap-3">
+							<NavLink
+								to={ROUTES.LOGIN}
+								onClick={onClose}
+								className="block w-full px-4 py-3 rounded-lg text-white font-medium text-center hover:opacity-90 transition-opacity"
+								style={{ background: "#3434a5" }}
+							>
+								Sign In
+							</NavLink>
+							<button
+								onClick={() => {
+									onGuestLogin();
+									onClose();
+								}}
+								className="w-full px-4 py-3 rounded-lg text-white/85 font-medium text-center underline hover:text-white transition-colors"
+							>
+								Continue as Guest
+							</button>
+						</div>
 					)}
 				</div>
 			</div>

--- a/src/components/Navbar/Navbar.module.css
+++ b/src/components/Navbar/Navbar.module.css
@@ -2,7 +2,7 @@
   position: sticky;
   top: 0;
   z-index: 40;
-  background: var(--grad-page);
+  background: var(--royal);
   border-bottom: 1px solid var(--border-strong);
 }
 
@@ -26,23 +26,11 @@
   text-decoration: none;
 }
 
-.navMark {
-  width: 64px;
-  height: 64px;
-  border-radius: 14px;
-  background: var(--royal);
-  border: 1.5px solid rgba(245, 159, 0, 0.35);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
 .wordmark {
   font-family: var(--font-display);
   font-size: var(--text-lg);
   font-weight: 600;
-  color: #fff;
+  color: var(--gold);
 }
 
 /* ── Desktop nav links ── */
@@ -98,7 +86,7 @@
   white-space: nowrap;
   font-size: var(--text-sm);
   font-weight: 600;
-  color: #fff;
+  color: var(--gold);
   background: var(--royal);
   border: 1.5px solid rgba(245, 159, 0, 0.3);
   padding: 0.5rem 1.25rem;

--- a/src/components/Navbar/Navbar.module.css
+++ b/src/components/Navbar/Navbar.module.css
@@ -99,6 +99,32 @@
   opacity: 0.9;
 }
 
+.guestLink {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  background: transparent;
+  border: none;
+  padding: 0.5rem 0.25rem;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.15s;
+}
+
+.guestLink:hover {
+  color: #fff;
+}
+
+.guestLink:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-royal);
+  border-radius: 4px;
+}
+
 /* ── Mobile hamburger ── */
 .hamburger {
   display: flex;

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -4,7 +4,6 @@ import { useAuth } from "../../hooks/useAuth";
 import { ROUTES, APP_NAME } from "../../constants";
 import UserInfo from "./UserInfo";
 import MobileMenu from "./MobileMenu";
-import PegasusIcon from "../common/PegasusIcon";
 import styles from "./Navbar.module.css";
 
 const navLinks = [
@@ -31,10 +30,7 @@ const Navbar = () => {
         <div className={styles.row}>
           {/* Brand */}
           <NavLink to={ROUTES.HOME} className={styles.brand}>
-            <div className={styles.navMark}>
-              <PegasusIcon width={38} height={38} />
-            </div>
-            <span className={styles.wordmark}>{APP_NAME}</span>
+<span className={styles.wordmark}>{APP_NAME}</span>
           </NavLink>
 
           {/* Desktop nav links */}

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -16,12 +16,21 @@ const navLinks = [
 
 const Navbar = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const { user, isAuthenticated, logout } = useAuth();
+  const { user, isAuthenticated, logout, loginAsGuest } = useAuth();
   const navigate = useNavigate();
 
   const handleLogout = () => {
     logout();
     navigate(ROUTES.LOGIN);
+  };
+
+  const handleGuestLogin = async () => {
+    try {
+      await loginAsGuest();
+      navigate(ROUTES.HOME);
+    } catch (error) {
+      console.error("Guest login failed:", error);
+    }
   };
 
   return (
@@ -55,9 +64,14 @@ const Navbar = () => {
             {isAuthenticated && user ? (
               <UserInfo username={user.username} coins={user.coins} />
             ) : (
-              <NavLink to={ROUTES.LOGIN} className={styles.signInPill}>
-                Sign In
-              </NavLink>
+              <>
+                <button onClick={handleGuestLogin} className={styles.guestLink}>
+                  Continue as Guest
+                </button>
+                <NavLink to={ROUTES.LOGIN} className={styles.signInPill}>
+                  Sign In
+                </NavLink>
+              </>
             )}
           </div>
 
@@ -92,6 +106,7 @@ const Navbar = () => {
         isAuthenticated={isAuthenticated}
         user={user}
         onLogout={handleLogout}
+        onGuestLogin={handleGuestLogin}
       />
     </header>
   );

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -12,6 +12,7 @@ interface AuthContextType {
 	isAuthenticated: boolean;
 	isLoading: boolean;
 	login: (email: string, password: string) => Promise<void>;
+	loginAsGuest: () => Promise<void>;
 	register: (
 		username: string,
 		firstName: string,

--- a/src/pages/Login.module.css
+++ b/src/pages/Login.module.css
@@ -180,6 +180,36 @@
   cursor: not-allowed;
 }
 
+.guestBtn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 9px;
+  border: 1.5px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-body);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+  margin-top: 0.75rem;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.guestBtn:hover:not(:disabled) {
+  background: var(--bg-subtle);
+}
+
+.guestBtn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-royal);
+}
+
+.guestBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ── Sign up prompt ── */
 .signupPrompt {
   font-size: var(--text-sm);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -12,7 +12,7 @@ const Login: React.FC = () => {
   const [errors, setErrors] = useState({ email: "", password: "", general: "" });
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-  const { login } = useAuth();
+  const { login, loginAsGuest } = useAuth();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -42,6 +42,23 @@ const Login: React.FC = () => {
         email: "",
         password: "",
         general: err.response?.data?.error || "Login failed. Please try again.",
+      });
+      setLoading(false);
+    }
+  };
+
+  const handleGuestLogin = async () => {
+    setLoading(true);
+    setErrors({ email: "", password: "", general: "" });
+
+    try {
+      await loginAsGuest();
+      navigate(ROUTES.PROFILE);
+    } catch (err: any) {
+      setErrors({
+        email: "",
+        password: "",
+        general: "Guest login failed. Please try again.",
       });
       setLoading(false);
     }
@@ -126,6 +143,15 @@ const Login: React.FC = () => {
 
             <button type="submit" disabled={loading} className={styles.submitBtn}>
               {loading ? "Signing in…" : "Sign In"}
+            </button>
+
+            <button
+              type="button"
+              disabled={loading}
+              onClick={handleGuestLogin}
+              className={styles.guestBtn}
+            >
+              Continue as Guest
             </button>
           </form>
 

--- a/src/pages/Marketplace/Marketplace.module.css
+++ b/src/pages/Marketplace/Marketplace.module.css
@@ -11,9 +11,9 @@
 .heroMark {
   width: 100px;
   height: 100px;
-  border-radius: 22px;
-  background: var(--royal);
-  border: 2px solid rgba(245, 159, 0, 0.35);
+  /* border-radius: 22px; */
+  /* background: var(--royal); */
+  /* border: 2px solid rgba(245, 159, 0, 0.35); */
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/Marketplace/index.tsx
+++ b/src/pages/Marketplace/index.tsx
@@ -9,121 +9,124 @@ import CategoryFilter from "./CategoryFilter";
 import styles from "./Marketplace.module.css";
 
 const Marketplace = () => {
-	const navigate = useNavigate();
-	const { isAuthenticated } = useAuth();
-	const [selectedCategory, setSelectedCategory] = useState("All");
-	const [searchQuery, setSearchQuery] = useState("");
-	const [products, setProducts] = useState<Product[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
-	const [addingToCart, setAddingToCart] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+  const [selectedCategory, setSelectedCategory] = useState("All");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [addingToCart, setAddingToCart] = useState<string | null>(null);
 
-	useEffect(() => {
-		const fetchProducts = async () => {
-			try {
-				const data = await productService.getProducts();
-				setProducts(data);
-			} catch (err) {
-				setError("Failed to load products");
-				console.error(err);
-			} finally {
-				setLoading(false);
-			}
-		};
-		fetchProducts();
-	}, []);
+  useEffect(() => {
+    const fetchProducts = async () => {
+      try {
+        const data = await productService.getProducts();
+        setProducts(data);
+      } catch (err) {
+        setError("Failed to load products");
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchProducts();
+  }, []);
 
-	const handleAddToCart = async (productId: string) => {
-		if (!isAuthenticated) {
-			navigate("/login");
-			return;
-		}
-		const product = products.find((p) => p.id === productId);
-		if (!product || product.stock === 0) return;
+  const handleAddToCart = async (productId: string) => {
+    if (!isAuthenticated) {
+      navigate("/login");
+      return;
+    }
+    const product = products.find((p) => p.id === productId);
+    if (!product || product.stock === 0) return;
 
-		setAddingToCart(productId);
-		try {
-			await cartService.addToCart(productId, 1);
-		} catch (err) {
-			console.error("Failed to add to cart:", err);
-		} finally {
-			setAddingToCart(null);
-		}
-	};
+    setAddingToCart(productId);
+    try {
+      await cartService.addToCart(productId, 1);
+    } catch (err) {
+      console.error("Failed to add to cart:", err);
+    } finally {
+      setAddingToCart(null);
+    }
+  };
 
-	const categories = ["All", ...new Set(products.map((p) => p.category))];
+  const categories = ["All", ...new Set(products.map((p) => p.category))];
 
-	const filteredProducts = products.filter((product) => {
-		const matchesCategory =
-			selectedCategory === "All" || product.category === selectedCategory;
-		const matchesSearch =
-			product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-			product.description.toLowerCase().includes(searchQuery.toLowerCase());
-		return matchesCategory && matchesSearch && product.is_available;
-	});
+  const filteredProducts = products.filter((product) => {
+    const matchesCategory =
+      selectedCategory === "All" || product.category === selectedCategory;
+    const matchesSearch =
+      product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      product.description.toLowerCase().includes(searchQuery.toLowerCase());
+    return matchesCategory && matchesSearch && product.is_available;
+  });
 
-	return (
-		<div>
-			{/* Hero */}
-			<section className={styles.hero}>
-				<div className={styles.heroMark}>
-					<PegasusIcon width={70} height={70} />
-				</div>
-				<h1 className={styles.heroTitle}>Welcome to Golden Market</h1>
-				<p className={styles.heroSubtitle}>
-					Discover legendary items and rare treasures from across the realm
-				</p>
-				<div className={styles.searchWrap}>
-					<input
-						type="text"
-						placeholder="Search for items…"
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
-						className={styles.searchInput}
-					/>
-				</div>
-			</section>
+  return (
+    <div>
+      {/* Hero */}
+      <section className={styles.hero}>
+        <div className={styles.heroMark}>
+          <PegasusIcon width={100} height={74} />
+        </div>
+        <h1 className={styles.heroTitle}>Welcome to Golden Market</h1>
+        <p className={styles.heroSubtitle}>
+          Discover legendary items and rare treasures from across the realm
+        </p>
+        <div className={styles.searchWrap}>
+          <input
+            type="text"
+            placeholder="Search for items…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className={styles.searchInput}
+          />
+        </div>
+      </section>
 
-			{/* Main content */}
-			<div className={styles.content}>
-				{loading && (
-					<p className={styles.stateMessage}>Loading products...</p>
-				)}
+      {/* Main content */}
+      <div className={styles.content}>
+        {loading && <p className={styles.stateMessage}>Loading products...</p>}
 
-				{error && (
-					<div className={styles.errorMessage}>
-						<p className={styles.errorText}>{error}</p>
-						<button className={styles.retryButton} onClick={() => window.location.reload()}>
-							Try Again
-						</button>
-					</div>
-				)}
+        {error && (
+          <div className={styles.errorMessage}>
+            <p className={styles.errorText}>{error}</p>
+            <button
+              className={styles.retryButton}
+              onClick={() => window.location.reload()}
+            >
+              Try Again
+            </button>
+          </div>
+        )}
 
-				{!loading && !error && (
-					<>
-						<CategoryFilter
-							categories={categories}
-							selectedCategory={selectedCategory}
-							onSelect={setSelectedCategory}
-						/>
-						<div className={styles.grid}>
-							{filteredProducts.map((product) => (
-								<ProductCard
-									key={product.id}
-									product={product}
-									onAddToCart={handleAddToCart}
-									isAdding={addingToCart === product.id}
-								/>
-							))}
-						</div>
-						{filteredProducts.length === 0 && (
-							<p className={styles.stateMessage}>No items found — try adjusting your search or filters.</p>
-						)}
-					</>
-				)}
-			</div>
-		</div>
-	);
+        {!loading && !error && (
+          <>
+            <CategoryFilter
+              categories={categories}
+              selectedCategory={selectedCategory}
+              onSelect={setSelectedCategory}
+            />
+            <div className={styles.grid}>
+              {filteredProducts.map((product) => (
+                <ProductCard
+                  key={product.id}
+                  product={product}
+                  onAddToCart={handleAddToCart}
+                  isAdding={addingToCart === product.id}
+                />
+              ))}
+            </div>
+            {filteredProducts.length === 0 && (
+              <p className={styles.stateMessage}>
+                No items found — try adjusting your search or filters.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default Marketplace;

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -48,6 +48,11 @@ export const authService = {
 		return response.data;
 	},
 
+	guestLogin: async () => {
+		const response = await apiClient.post<LoginResponse>("/auth/guest-login");
+		return response.data;
+	},
+
 	refresh: async (refreshToken: string) => {
 		const response = await apiClient.post<RefreshResponse>("/auth/refresh", {
 			refresh_token: refreshToken,

--- a/src/store/AuthContext.tsx
+++ b/src/store/AuthContext.tsx
@@ -39,11 +39,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		loadUser();
 	}, []);
 
-	const login = async (email: string, password: string) => {
-		const data = await authService.login({ email, password });
-		setAccessToken(data.token);
+	// Shared by login and loginAsGuest: takes the access token from either
+	// flow, fetches the profile, and settles auth state.
+	const completeLogin = async (token: string) => {
+		setAccessToken(token);
 
-		// Fetch user profile after successful login
 		let userData;
 		try {
 			const profile = await userService.getProfile();
@@ -62,6 +62,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
 		localStorage.setItem("user", JSON.stringify(userData));
 		setUser(userData);
+	};
+
+	const login = async (email: string, password: string) => {
+		const data = await authService.login({ email, password });
+		await completeLogin(data.token);
+	};
+
+	const loginAsGuest = async () => {
+		const data = await authService.guestLogin();
+		await completeLogin(data.token);
 	};
 
 	const register = async (
@@ -115,6 +125,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 				isAuthenticated: !!user,
 				isLoading,
 				login,
+				loginAsGuest,
 				register,
 				logout,
 				refreshUser,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,11 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
 	base: '/golden-market/',
 	plugins: [
-		react({
-			babel: {
-				plugins: [["babel-plugin-react-compiler"]],
-			},
-		}),
+		react(),
 		tailwindcss(),
 	],
 });


### PR DESCRIPTION
## Summary
- New `POST /auth/guest-login` endpoint backed by a single shared guest account (`is_guest` flag on `users`)
- Account is lazy-created on first use, and fully wiped (cart/inventory/orders deleted, balance reset to 5000) on every subsequent login so each guest session starts fresh
- Reuses the existing Login token-issuance path — real JWT, no fake/client-only auth state

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] Verified end-to-end locally against a live Postgres instance: first call creates the guest account with a 5000 coin balance; after manually spending coins and adding a cart item, a second call resets the balance to 5000 and clears the cart while reusing the same guest account row