### PR TITLE
Add guest login to Navbar and Login page

### DIFF
--- a/src/components/Navbar/MobileMenu.tsx
+++ b/src/components/Navbar/MobileMenu.tsx
@@ -9,6 +9,7 @@ interface MobileMenuProps {
 	isAuthenticated: boolean;
 	user: { username: string; coins: number } | null;
 	onLogout: () => void;
+	onGuestLogin: () => void;
 }
 
 const navLinks = [
@@ -25,6 +26,7 @@ const MobileMenu = ({
 	isAuthenticated,
 	user,
 	onLogout,
+	onGuestLogin,
 }: MobileMenuProps) => {
 	const menuRef = useRef<HTMLDivElement>(null);
 
@@ -123,14 +125,25 @@ const MobileMenu = ({
 							Sign Out
 						</button>
 					) : (
-						<NavLink
-							to={ROUTES.LOGIN}
-							onClick={onClose}
-							className="block w-full px-4 py-3 rounded-lg text-white font-medium text-center hover:opacity-90 transition-opacity"
-							style={{ background: "#3434a5" }}
-						>
-							Sign In
-						</NavLink>
+						<div className="flex flex-col gap-3">
+							<NavLink
+								to={ROUTES.LOGIN}
+								onClick={onClose}
+								className="block w-full px-4 py-3 rounded-lg text-white font-medium text-center hover:opacity-90 transition-opacity"
+								style={{ background: "#3434a5" }}
+							>
+								Sign In
+							</NavLink>
+							<button
+								onClick={() => {
+									onGuestLogin();
+									onClose();
+								}}
+								className="w-full px-4 py-3 rounded-lg text-white/85 font-medium text-center underline hover:text-white transition-colors"
+							>
+								Continue as Guest
+							</button>
+						</div>
 					)}
 				</div>
 			</div>

--- a/src/components/Navbar/Navbar.module.css
+++ b/src/components/Navbar/Navbar.module.css
@@ -99,6 +99,32 @@
   opacity: 0.9;
 }
 
+.guestLink {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  background: transparent;
+  border: none;
+  padding: 0.5rem 0.25rem;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.15s;
+}
+
+.guestLink:hover {
+  color: #fff;
+}
+
+.guestLink:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-royal);
+  border-radius: 4px;
+}
+
 /* ── Mobile hamburger ── */
 .hamburger {
   display: flex;

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -16,12 +16,21 @@ const navLinks = [
 
 const Navbar = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const { user, isAuthenticated, logout } = useAuth();
+  const { user, isAuthenticated, logout, loginAsGuest } = useAuth();
   const navigate = useNavigate();
 
   const handleLogout = () => {
     logout();
     navigate(ROUTES.LOGIN);
+  };
+
+  const handleGuestLogin = async () => {
+    try {
+      await loginAsGuest();
+      navigate(ROUTES.HOME);
+    } catch (error) {
+      console.error("Guest login failed:", error);
+    }
   };
 
   return (
@@ -55,9 +64,14 @@ const Navbar = () => {
             {isAuthenticated && user ? (
               <UserInfo username={user.username} coins={user.coins} />
             ) : (
-              <NavLink to={ROUTES.LOGIN} className={styles.signInPill}>
-                Sign In
-              </NavLink>
+              <>
+                <button onClick={handleGuestLogin} className={styles.guestLink}>
+                  Continue as Guest
+                </button>
+                <NavLink to={ROUTES.LOGIN} className={styles.signInPill}>
+                  Sign In
+                </NavLink>
+              </>
             )}
           </div>
 
@@ -92,6 +106,7 @@ const Navbar = () => {
         isAuthenticated={isAuthenticated}
         user={user}
         onLogout={handleLogout}
+        onGuestLogin={handleGuestLogin}
       />
     </header>
   );

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -12,6 +12,7 @@ interface AuthContextType {
 	isAuthenticated: boolean;
 	isLoading: boolean;
 	login: (email: string, password: string) => Promise<void>;
+	loginAsGuest: () => Promise<void>;
 	register: (
 		username: string,
 		firstName: string,

--- a/src/pages/Login.module.css
+++ b/src/pages/Login.module.css
@@ -180,6 +180,36 @@
   cursor: not-allowed;
 }
 
+.guestBtn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 9px;
+  border: 1.5px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-body);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+  margin-top: 0.75rem;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.guestBtn:hover:not(:disabled) {
+  background: var(--bg-subtle);
+}
+
+.guestBtn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-royal);
+}
+
+.guestBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ── Sign up prompt ── */
 .signupPrompt {
   font-size: var(--text-sm);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -12,7 +12,7 @@ const Login: React.FC = () => {
   const [errors, setErrors] = useState({ email: "", password: "", general: "" });
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-  const { login } = useAuth();
+  const { login, loginAsGuest } = useAuth();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -42,6 +42,23 @@ const Login: React.FC = () => {
         email: "",
         password: "",
         general: err.response?.data?.error || "Login failed. Please try again.",
+      });
+      setLoading(false);
+    }
+  };
+
+  const handleGuestLogin = async () => {
+    setLoading(true);
+    setErrors({ email: "", password: "", general: "" });
+
+    try {
+      await loginAsGuest();
+      navigate(ROUTES.PROFILE);
+    } catch (err: any) {
+      setErrors({
+        email: "",
+        password: "",
+        general: "Guest login failed. Please try again.",
       });
       setLoading(false);
     }
@@ -126,6 +143,15 @@ const Login: React.FC = () => {
 
             <button type="submit" disabled={loading} className={styles.submitBtn}>
               {loading ? "Signing in…" : "Sign In"}
+            </button>
+
+            <button
+              type="button"
+              disabled={loading}
+              onClick={handleGuestLogin}
+              className={styles.guestBtn}
+            >
+              Continue as Guest
             </button>
           </form>
 

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -48,6 +48,11 @@ export const authService = {
 		return response.data;
 	},
 
+	guestLogin: async () => {
+		const response = await apiClient.post<LoginResponse>("/auth/guest-login");
+		return response.data;
+	},
+
 	refresh: async (refreshToken: string) => {
 		const response = await apiClient.post<RefreshResponse>("/auth/refresh", {
 			refresh_token: refreshToken,

--- a/src/store/AuthContext.tsx
+++ b/src/store/AuthContext.tsx
@@ -39,11 +39,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		loadUser();
 	}, []);
 
-	const login = async (email: string, password: string) => {
-		const data = await authService.login({ email, password });
-		setAccessToken(data.token);
+	// Shared by login and loginAsGuest: takes the access token from either
+	// flow, fetches the profile, and settles auth state.
+	const completeLogin = async (token: string) => {
+		setAccessToken(token);
 
-		// Fetch user profile after successful login
 		let userData;
 		try {
 			const profile = await userService.getProfile();
@@ -62,6 +62,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
 		localStorage.setItem("user", JSON.stringify(userData));
 		setUser(userData);
+	};
+
+	const login = async (email: string, password: string) => {
+		const data = await authService.login({ email, password });
+		await completeLogin(data.token);
+	};
+
+	const loginAsGuest = async () => {
+		const data = await authService.guestLogin();
+		await completeLogin(data.token);
 	};
 
 	const register = async (
@@ -115,6 +125,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 				isAuthenticated: !!user,
 				isLoading,
 				login,
+				loginAsGuest,
 				register,
 				logout,
 				refreshUser,


### PR DESCRIPTION
## Summary
- `AuthContext.loginAsGuest()` — shares a `completeLogin` helper with the existing `login()` flow
- "Continue as Guest" action added next to Sign In in the desktop Navbar, mobile menu, and Login page

Depends on the companion backend PR (diorshelton/golden-market-api) adding `POST /auth/guest-login`.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Manually tested in the browser against the local backend — guest login works end-to-end